### PR TITLE
Fix bug when img is a string not object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photoswipe",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "engines": {
     "node": ">= 0.8.0"
   },

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -202,8 +202,10 @@ var _getItemAt,
 			item.placeholder.style.height = h + 'px';
 		}
 
-		img.style.width = w + 'px';
-		img.style.height = h + 'px';
+		if(img && img.style) {
+            img.style.width = w + 'px';
+            img.style.height = h + 'px';
+		}
 	},
 	_appendImagesPool = function() {
 

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -203,8 +203,8 @@ var _getItemAt,
 		}
 
 		if(img && img.style) {
-            img.style.width = w + 'px';
-            img.style.height = h + 'px';
+		    img.style.width = w + 'px';
+		    img.style.height = h + 'px';
 		}
 	},
 	_appendImagesPool = function() {


### PR DESCRIPTION
There is a bug when image href is broken (returns 404) and gallery shows errorMsg. In that moment we are trying to change style property, but it doesn't exist. Because in that case img is a string.